### PR TITLE
move templates folder Project Level

### DIFF
--- a/templates/book_detail.html
+++ b/templates/book_detail.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ book.title }}</title>
+</head>
+<body>
+    <h1>{{ book.title }}</h1>
+    <p><strong>Author:</strong> {{ book.author }}</p>
+    <p><strong>Publication Date:</strong> {{ book.publication_date }}</p>
+    <p><strong>Description:</strong> {{ book.description }}</p>
+    <p><strong>Price:</strong> ${{ book.price }}</p>
+    {% if book.cover_image %}
+        <img src="{{ book.cover_image.url }}" alt="Cover image of {{ book.title }}">
+    {% endif %}
+</body>
+</html>

--- a/templates/book_list.html
+++ b/templates/book_list.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Book List</title>
+</head>
+<body>
+    <h1>Book List</h1>
+    <ul>
+        {% for book in books %}
+            <li><a href="{% url 'book_detail' pk=book.pk %}">{{ book.title }}</a> by {{ book.author }}</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
As Django projects grow, having all the templates in one place is often more convenient than hunting for them within multiple apps.